### PR TITLE
Don't stop event propagation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -158,11 +158,6 @@ class Interactive {
     // Add "e" property for backwards compatibility with wax.
     event.e = event.originalEvent || { type: eventType };
 
-    // To emulate wax behaviour stop event propagation when there is data.
-    if (event.data && event.originalEvent) {
-      event.originalEvent.stopPropagation();
-    }
-
     this._triggerEvent(eventType, event);
   }
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@carto/zera",
   "version": "1.0.6",
-  "main": "lib/index.js",
+  "main": "dist/zera.js",
   "license": "BSD-3-Clause",
   "files": [
-    "lib"
+    "dist"
   ],
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carto/zera",
   "version": "1.0.6",
-  "main": "dist/zera.js",
+  "main": "src/zera.js",
   "license": "BSD-3-Clause",
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/zera",
-  "version": "1.0.6-staging",
+  "version": "1.0.6",
   "main": "dist/zera.js",
   "license": "BSD-3-Clause",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@carto/zera",
   "version": "1.0.6",
-  "main": "src/zera.js",
+  "main": "lib/index.js",
   "license": "BSD-3-Clause",
   "files": [
-    "dist"
+    "lib"
   ],
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/zera",
-  "version": "1.0.6",
+  "version": "1.0.6-staging",
   "main": "dist/zera.js",
   "license": "BSD-3-Clause",
   "files": [


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/14115

### Description
This PR fixes a bug introduced in https://github.com/CartoDB/zera/commit/317a82f61b137299f6b959b2addc65c52dd11df0 while trying to fix https://github.com/CartoDB/carto.js/issues/1952

The problem is that Builder is listening directly to document click events, so it closes the edit button as soon as soon as it's shown. Instead of stopping the event propagation to avoid that error we're going to handle it using carto.js events and stop listening to document click.
